### PR TITLE
Fix issues arising from using BUILD_JOBS=1.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,6 @@
 [submodule "src/model/CMAQ"]
 	path = src/model/CMAQ
-	url = https://github.com/USEPA/CMAQ.git
-	branch = 5.2.1
+	url = https://github.com/BrianCurtis-NOAA/CMAQ
+	branch = feature/aqm_test
+	#url = https://github.com/NOAA-EMC/CMAQ
+	#branch = dev/emc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,4 @@
 [submodule "src/model/CMAQ"]
 	path = src/model/CMAQ
-	url = https://github.com/BrianCurtis-NOAA/CMAQ
-	branch = feature/aqm_test
-	#url = https://github.com/NOAA-EMC/CMAQ
-	#branch = dev/emc
+	url = https://github.com/NOAA-EMC/CMAQ
+	branch = dev/emc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,32 +28,29 @@ include("aqm_files.cmake")
 
 # src/shr
 add_library(shr OBJECT ${aqm_shr_files})
-#add_dependencies(shr drv aqmio ioapi CCTM)
+add_dependencies(shr ioapi aqmio)
 set_target_properties(shr PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod)
-target_include_directories(shr PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>)
-target_include_directories(shr PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/model/CMAQ/CCTM/src/ICL/fixed/filenames>
+target_include_directories(shr PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
+                                       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/model/CMAQ/CCTM/src/ICL/fixed/filenames>
                                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/model/CMAQ/CCTM/src/ICL/fixed/const>
 				       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/io/ioapi>
 				       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/io/aqmio>
 				       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/model>)
 target_compile_definitions(shr PUBLIC SUBST_CONST="CONST.EXT" 
 				      SUBST_FILES_ID="FILES_CTM.EXT")
-#target_link_libraries(shr PRIVATE drv aqmio ioapi CCTM)
 target_link_libraries(shr PRIVATE esmf)
 
 # src/drv
 add_library(drv OBJECT ${aqm_drv_files})
-#add_dependencies(drv shr CCTM aqmio ioapi)
 add_dependencies(drv shr)
 set_target_properties(drv PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod)
-target_include_directories(drv PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>)
-target_include_directories(drv PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/shr>
+target_include_directories(drv PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
+                                       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/shr>
                                        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/io/ioapi>
                                        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/io/aqmio>
                                        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/model>)
 target_compile_definitions(drv PUBLIC verbose_driver)
-target_link_libraries(drv PRIVATE shr, CCTM)
-target_link_libraries(drv PRIVATE esmf)
+target_link_libraries(drv PRIVATE shr CCTM esmf)
 
 # src/io/aqmio
 add_library(aqmio OBJECT ${aqm_aqmio_files})
@@ -64,23 +61,23 @@ target_link_libraries(aqmio PRIVATE esmf)
 # src/io/ioapi
 add_library(ioapi OBJECT ${aqm_ioapi_files})
 set_target_properties(ioapi PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod)
-target_include_directories(ioapi PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>)
-target_include_directories(ioapi PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/model/CMAQ/CCTM/src/ICL/fixed/filenames>)
+target_include_directories(ioapi PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
+                                         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/model/CMAQ/CCTM/src/ICL/fixed/filenames>)
 target_compile_definitions(ioapi PUBLIC SUBST_FILES_ID="FILES_CTM.EXT")
 target_link_libraries(ioapi PRIVATE esmf)
 
 # src/model
 add_library(CCTM OBJECT ${aqm_CCTM_files})
-#add_dependencies(CCTM shr aqmio ioapi)
+add_dependencies(CCTM shr aqmio ioapi)
 set_target_properties(CCTM PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod)
-target_include_directories(CCTM PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>)
-target_include_directories(CCTM PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/model/CMAQ/CCTM/src/ICL/fixed/filenames>
-                                         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/model/CMAQ/CCTM/src/ICL/fixed/const>
-                                         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/model/CMAQ/CCTM/src/ICL/fixed/emctrl>
-                                         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/model/CMAQ/CCTM/src/ICL/fixed/mpi>
-					 $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/shr>
-                                         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/io/ioapi>
-                                         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/io/aqmio>)
+target_include_directories(CCTM PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
+                                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/model/CMAQ/CCTM/src/ICL/fixed/filenames>
+                                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/model/CMAQ/CCTM/src/ICL/fixed/const>
+                                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/model/CMAQ/CCTM/src/ICL/fixed/emctrl>
+                                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/model/CMAQ/CCTM/src/ICL/fixed/mpi>
+					$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/shr>
+                                        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/io/ioapi>
+                                        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/io/aqmio>)
 target_compile_definitions(CCTM PUBLIC SUBST_FILES_ID="FILES_CTM.EXT"
                                        SUBST_CONST="CONST.EXT"
                                        SUBST_EMISPRM="EMISPRM.EXT"
@@ -88,8 +85,6 @@ target_compile_definitions(CCTM PUBLIC SUBST_FILES_ID="FILES_CTM.EXT"
                                        SUBST_COMM=NOOP_COMM
                                        SUBST_BARRIER=NOOP_BARRIER
                                        SUBST_SUBGRID_INDEX=NOOP_SUBGRID_INDEX
-                                       MOSAIC_MOD=MOSAIC_MODULE
-				       Mosaic_Mod=Mosaic_Module
                                        EDDYX=DUMMY_EDDYX
                                        OPCONC=DUMMY_OPCONC
 				       OPACONC=DUMMY_OPACONC
@@ -99,18 +94,14 @@ target_compile_definitions(CCTM PUBLIC SUBST_FILES_ID="FILES_CTM.EXT"
 				       verbose_gas
                                        mpas
 				       _AQM_)
-#target_link_libraries(CCTM PRIVATE shr aqmio ioapi)
-ADD_CUSTOM_TARGET(link_target ALL
-                  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_BINARY_DIR}/mod/mosaic_module.mod
-                  ${CMAKE_CURRENT_BINARY_DIR}/mod/mosaic_mod.mod)
 target_link_libraries(CCTM PRIVATE esmf)
 
 # AQM
 add_library(aqm STATIC ${aqm_files} $<TARGET_OBJECTS:shr>
-                         $<TARGET_OBJECTS:drv>
-                         $<TARGET_OBJECTS:aqmio>
-                         $<TARGET_OBJECTS:ioapi>
-                         $<TARGET_OBJECTS:CCTM>)
+                         	    $<TARGET_OBJECTS:drv>
+                         	    $<TARGET_OBJECTS:aqmio>
+                         	    $<TARGET_OBJECTS:ioapi>
+                         	    $<TARGET_OBJECTS:CCTM>)
 set_target_properties(aqm PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod)
 add_library(aqm::aqm ALIAS aqm)
 target_include_directories(aqm PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
@@ -139,10 +130,3 @@ install(EXPORT      AQMExports
         NAMESPACE   aqm::
         FILE        aqm-targets.cmake
         DESTINATION lib/cmake)
-
-# # create target
-# add_library(aqm OBJECT ${aqm_files})
-# set_property(TARGET aqm PROPERTY IMPORTED_LOCATION ${aqm_dir}/libaqm.a)
-# add_dependencies(aqm aqm_gnu)
-# target_include_directories(aqm INTERFACE ${aqm_dir})
-# target_link_libraries(aqm INTERFACE esmf NetCDF::NetCDF_Fortran)


### PR DESCRIPTION
When using BUILD_JOBS=4 or 8 the compiles on wcoss1 system (now gone) and cheyenne would not work. The fix was to test and fix errors with BUILD_JOBS=1.

This PR brings in the changes needed to compile with BUILD_JOBS=1 (make -j1).

Depends on:
NOAA-EMC/CMAQ/pull/1