### PR TITLE
Replace ESMF I/O format flags with AQMIO flags

### DIFF
--- a/src/shr/aqm_emis_mod.F90
+++ b/src/shr/aqm_emis_mod.F90
@@ -196,7 +196,7 @@ contains
       em(item) % file = ""
       em(item) % frequency = ""
       em(item) % format = "netcdf"
-      em(item) % iofmt = ESMF_IOFMT_NETCDF
+      em(item) % iofmt = AQMIO_FMT_NETCDF
       em(item) % irec  = 0
       em(item) % verbose     = .false.
       em(item) % logprefix   = ""
@@ -311,9 +311,9 @@ contains
 
     select case (trim(em % format))
       case ("binary")
-        em % iofmt = ESMF_IOFMT_BIN
+        em % iofmt = AQMIO_FMT_BIN
       case ("netcdf")
-        em % iofmt = ESMF_IOFMT_NETCDF
+        em % iofmt = AQMIO_FMT_NETCDF
       case default
         call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
           msg="- invalid emission format: "//trim(em % format), &
@@ -382,7 +382,7 @@ contains
       rcToReturn=rc)) &
       return  ! bail out
 
-    if (em % iofmt == ESMF_IOFMT_BIN) then
+    if (em % iofmt == AQMIO_FMT_BIN) then
       if (trim(em % frequency) /= "static") then
         em % frequency = "static"
         if (em % verbose) then
@@ -694,7 +694,7 @@ contains
         end if
 
         ! -- open single netCDF file if selected
-        if (em % iofmt == ESMF_IOFMT_NETCDF) then
+        if (em % iofmt == AQMIO_FMT_NETCDF) then
           call AQMIO_Open(em % IO, em % file, filePath=em % path, iomode="read", &
             iofmt=em % iofmt, rc=localrc)
           if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -1038,7 +1038,7 @@ contains
             rcToReturn=rc)) &
             return  ! bail out
         end if
-        if (em % iofmt == ESMF_IOFMT_BIN) then
+        if (em % iofmt == AQMIO_FMT_BIN) then
           do n = 1, size(em % sources)
             call AQMIO_Read(em % IO, (/ em % fields(n) /), fileName=em % sources(n), &
               filePath=em % path, iofmt=em % iofmt, rc=localrc)

--- a/src/shr/aqm_internal_mod.F90
+++ b/src/shr/aqm_internal_mod.F90
@@ -16,9 +16,9 @@ module aqm_internal_mod
     character(len=ESMF_MAXSTR)     :: specfile
     character(len=ESMF_MAXSTR)     :: specprofile
     character(len=6)               :: period
-    integer                        :: irec
     logical                        :: verbose
-    type(ESMF_IOFmt_flag)          :: iofmt
+    integer                        :: irec
+    integer                        :: iofmt
     type(ESMF_GridComp)            :: IO
     type(ESMF_Alarm)               :: alarm
     character(len=ESMF_MAXSTR), dimension(:),   pointer :: sources   => null()


### PR DESCRIPTION
This PR removes the AQM dependency from ESMF I/O format flags and introduces equivalent AQMIO flags to identify binary and NetCDF file formats.

This is to support ESMF 8.3.0 and later releases, as described in the ufs-weather-model issue [#1323](https://github.com/ufs-community/ufs-weather-model/issues/1323)

Closes #5 