### PR TITLE
Use correct variable for LUFRAC_ and DLUSE 

### DIFF
--- a/src/aqm_cap.F90
+++ b/src/aqm_cap.F90
@@ -9,11 +9,11 @@ module AQM
 
   use aqm_comp_mod
   use aqm_const_mod, only: rad_to_deg
-  
+
   implicit none
 
   ! -- import fields
-  integer, parameter :: importFieldCount = 36
+  integer, parameter :: importFieldCount = 37
   character(len=*), dimension(importFieldCount), parameter :: &
     importFieldNames = (/ &
       "canopy_moisture_storage                  ", &
@@ -51,7 +51,8 @@ module AQM
       "soil_type                                ", &
       "surface_cell_area                        ", &
       "surface_snow_area_fraction               ", &
-      "temperature_of_soil_layer                "  &
+      "temperature_of_soil_layer                ", &
+      "vtype                                   "  &  ! Add vtype field
     /)
   ! -- export fields
   integer, parameter :: exportFieldCount = 2
@@ -64,18 +65,18 @@ module AQM
   private
 
   public SetServices
-  
+
   !-----------------------------------------------------------------------------
   contains
   !-----------------------------------------------------------------------------
-  
+
   subroutine SetServices(model, rc)
     type(ESMF_GridComp)  :: model
     integer, intent(out) :: rc
 
     ! begin
     rc = ESMF_SUCCESS
-    
+
     ! the NUOPC model component will register the generic methods
     call NUOPC_CompDerive(model, inheritModel, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -120,7 +121,7 @@ module AQM
       return  ! bail out
 
   end subroutine
-  
+
   !-----------------------------------------------------------------------------
 
   subroutine InitializeP0(model, importState, exportState, clock, rc)
@@ -128,7 +129,7 @@ module AQM
     type(ESMF_State)     :: importState, exportState
     type(ESMF_Clock)     :: clock
     integer, intent(out) :: rc
-    
+
     ! local variables
     integer                    :: verbosity
     character(len=ESMF_MAXSTR) :: msgString, name, rcFile
@@ -195,16 +196,16 @@ module AQM
       line=__LINE__, &
       file=__FILE__)) &
       return  ! bail out
-    
+
   end subroutine
-  
+
   !-----------------------------------------------------------------------------
   subroutine InitializeP1(model, importState, exportState, clock, rc)
     type(ESMF_GridComp)  :: model
     type(ESMF_State)     :: importState, exportState
     type(ESMF_Clock)     :: clock
     integer, intent(out) :: rc
-    
+
     ! begin
     rc = ESMF_SUCCESS
 
@@ -285,7 +286,7 @@ module AQM
       return  ! bail out
 
     ! -- check if import fields are defined
-    if (importFieldCount < 1) then 
+    if (importFieldCount < 1) then
       call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
         msg="This component requires import fields to be defined.", &
         line=__LINE__, file=__FILE__, &
@@ -294,7 +295,7 @@ module AQM
     end if
 
     ! -- check if export fields are defined
-    if (exportFieldCount < 1) then 
+    if (exportFieldCount < 1) then
       call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
         msg="This component requires export fields to be defined.", &
         line=__LINE__, file=__FILE__, &
@@ -417,7 +418,7 @@ module AQM
             line=__LINE__, &
             file=__FILE__)) &
             return  ! bail out
-         
+
         do item = 1, 2
           call ESMF_GridGetCoord(grid, coordDim=item, staggerloc=ESMF_STAGGERLOC_CENTER, &
             localDE=localDe, farrayPtr=coord, rc=rc)
@@ -534,7 +535,7 @@ module AQM
   subroutine ModelAdvance(model, rc)
     type(ESMF_GridComp)  :: model
     integer, intent(out) :: rc
-    
+
     ! local variables
     type(ESMF_Clock)              :: clock
     type(ESMF_State)              :: importState, exportState
@@ -548,7 +549,7 @@ module AQM
 
     ! begin
     rc = ESMF_SUCCESS
-    
+
     ! get component's information
     call NUOPC_CompGet(model, name=name, diagnostic=diagnostic, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &

--- a/src/aqm_cap.F90
+++ b/src/aqm_cap.F90
@@ -52,7 +52,7 @@ module AQM
       "surface_cell_area                        ", &
       "surface_snow_area_fraction               ", &
       "temperature_of_soil_layer                ", &
-      "vtype                                   "  &  ! Add vtype field
+      "vegetation_type                          "  &
     /)
   ! -- export fields
   integer, parameter :: exportFieldCount = 2

--- a/src/aqm_comp_mod.F90
+++ b/src/aqm_comp_mod.F90
@@ -605,7 +605,7 @@ contains
               line=__LINE__, &
               file=__FILE__)) &
               return  ! bail
-          case ("vtype")
+          case ("vegetation_type")
             call ESMF_FieldGet(field, localDe=localDe, farrayPtr=stateIn % vtype, rc=rc)
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
               line=__LINE__, &

--- a/src/aqm_comp_mod.F90
+++ b/src/aqm_comp_mod.F90
@@ -605,6 +605,12 @@ contains
               line=__LINE__, &
               file=__FILE__)) &
               return  ! bail
+          case ("vtype")
+            call ESMF_FieldGet(field, localDe=localDe, farrayPtr=stateIn % vtype, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail
           case default
             ! -- unused field
         end select

--- a/src/shr/aqm_methods.F90
+++ b/src/shr/aqm_methods.F90
@@ -692,6 +692,14 @@ logical function interpx( fname, vname, pname, &
           end do
         case ('MSFX2')
           buffer(1:lbuf) = 1.
+        case ('DLUSE')
+          k = 0
+          do r = row0, row1
+            do c = col0, col1
+              k = k + 1
+              buffer(k) = stateIn % vtype(c,r)  ! Assign vtype to DLUSE
+            end do
+          end do
         case ('PURB')
         case default
           return

--- a/src/shr/aqm_methods.F90
+++ b/src/shr/aqm_methods.F90
@@ -88,7 +88,7 @@ LOGICAL FUNCTION DESC3( FNAME )
   CHARACTER(LEN=*), INTENT(IN) :: FNAME
 
   INCLUDE SUBST_FILES_ID
- 
+
   integer :: localrc
   integer :: is, ie, js, je
   integer :: EMLAYS
@@ -588,7 +588,7 @@ subroutine nameval(name, eqname)
     case default
       ! -- nothing to do
   end select
-  
+
 end subroutine nameval
 
 
@@ -660,7 +660,7 @@ logical function interpx( fname, vname, pname, &
       do r = row0, row1
         do c = col0, col1
           k = k + 1
-          if (int(stateIn % stype(c,r)) == lu_index) buffer(k) = 1.0
+          if (int(stateIn % vtype(c,r)) == lu_index) buffer(k) = 1.0  ! Assign vtype to LUFRAC_
         end do
       end do
     else
@@ -703,7 +703,7 @@ logical function interpx( fname, vname, pname, &
     call aqm_model_get(stateIn=stateIn, rc=localrc)
     if (aqm_rc_check(localrc, msg="Failure to retrieve model input state", &
       file=__FILE__, line=__LINE__)) return
-    
+
     call aqm_model_get(config=config, stateIn=stateIn, rc=localrc)
     if (aqm_rc_check(localrc, msg="Failure to retrieve model input state", &
       file=__FILE__, line=__LINE__)) return

--- a/src/shr/aqm_state_mod.F90
+++ b/src/shr/aqm_state_mod.F90
@@ -6,48 +6,52 @@ module aqm_state_mod
 
   type aqm_state_type
 
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: area     => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: cmm      => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: fice     => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: hfx      => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: hpbl     => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: ht       => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: lh       => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: psfc     => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: q2m      => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: rain     => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: rainc    => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: rgrnd    => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: rc       => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: slmsk    => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: sncov    => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: stype    => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: t2m      => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: tsfc     => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: ustar    => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: u10m     => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: v10m     => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: vfrac    => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: wr       => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: xlai     => null()
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: zorl     => null()
+    ! 2D Variables
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: area     => null()  ! Surface area
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: vtype    => null()  ! Vegetation type
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: cmm      => null()  ! Cloud mixing ratio
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: fice     => null()  ! Fraction of ice
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: hfx      => null()  ! Heat flux
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: hpbl     => null()  ! Planetary boundary layer height
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: ht       => null()  ! Height
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: lh       => null()  ! Latent heat
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: psfc     => null()  ! Surface pressure
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: q2m      => null()  ! Specific humidity at 2 meters
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: rain     => null()  ! Rainfall
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: rainc    => null()  ! Convective rainfall
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: rgrnd    => null()  ! Ground reflectance
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: rc       => null()  ! Cloud fraction
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: slmsk    => null()  ! Land-sea mask
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: sncov    => null()  ! Snow cover
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: stype    => null()  ! Soil type
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: t2m      => null()  ! Temperature at 2 meters
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: tsfc     => null()  ! Surface temperature
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: ustar    => null()  ! Friction velocity
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: u10m     => null()  ! U-component of wind at 10 meters
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: v10m     => null()  ! V-component of wind at 10 meters
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: vfrac    => null()  ! Vegetation fraction
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: wr       => null()  ! Water runoff
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: xlai     => null()  ! Leaf area index
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: zorl     => null()  ! Roughness length
 
-    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: cldfl    => null()
-    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: dkt      => null()
-    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: phii     => null()
-    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: phil     => null()
-    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: pri      => null()
-    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: prl      => null()
-    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: smois    => null()
-    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: stemp    => null()
-    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: temp     => null()
-    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: uwind    => null()
-    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: vwind    => null()
+    ! 3D Variables
+    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: cldfl    => null()  ! Cloud fraction
+    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: dkt      => null()  ! Diffusivity
+    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: phii     => null()  ! Geopotential height at interface
+    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: phil     => null()  ! Geopotential height at layer
+    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: pri      => null()  ! Precipitation rate at interface
+    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: prl      => null()  ! Precipitation rate at layer
+    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: smois    => null()  ! Soil moisture
+    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: stemp    => null()  ! Soil temperature
+    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: temp     => null()  ! Temperature
+    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: uwind    => null()  ! U-component of wind
+    real(AQM_KIND_R8), dimension(:,:,:),   pointer :: vwind    => null()  ! V-component of wind
 
-    real(AQM_KIND_R8), dimension(:,:,:,:), pointer :: tr       => null()
+    ! 4D Variables
+    real(AQM_KIND_R8), dimension(:,:,:,:), pointer :: tr       => null()  ! Tracer concentration
 
     ! -- diagnostics
-    real(AQM_KIND_R8), dimension(:,:),     pointer :: aod      => null()
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: aod      => null()  ! Aerosol optical depth
 
   end type aqm_state_type
 


### PR DESCRIPTION
<!--Instructions: All subsequent sections of text should be filled in as appropriate.-->
This pull request introduces several changes to the `module AQM` and related files to add support for a new field, `vtype`, which represents vegetation type. The most important changes include updating the import field count, adding the `vtype` field to various sections, and modifying the `aqm_state_type` to include `vtype`. Will close https://github.com/NOAA-EMC/AQM/issues/102

Changes to support the new `vtype` field:

* [`src/aqm_cap.F90`](diffhunk://#diff-1b18b3a2fc2d6b2f584eb1ca949e71ec3bfb2a18764a1b97d40afeb37cc55fe4L16-R16): Updated the `importFieldCount` to 37 and added the `vtype` field to the list of import fields. [[1]](diffhunk://#diff-1b18b3a2fc2d6b2f584eb1ca949e71ec3bfb2a18764a1b97d40afeb37cc55fe4L16-R16) [[2]](diffhunk://#diff-1b18b3a2fc2d6b2f584eb1ca949e71ec3bfb2a18764a1b97d40afeb37cc55fe4L54-R55)

* [`src/aqm_comp_mod.F90`](diffhunk://#diff-cc22a1ec93d9fbd5ee5268d66cb983898abc3d3d1b9281a84c1bf075b47d1b2cR608-R613): Modified the `aqm_comp_import` subroutine to handle the new `vtype` field.

* [`src/shr/aqm_methods.F90`](diffhunk://#diff-ae86eb8dcd46347a339a36a3753a9b28492431009c820d8624ddaf4080c17c15L663-R663): Updated the `interpx` function to use the `vtype` field for the 'LUFRAC_' and 'DLUSE' cases. [[1]](diffhunk://#diff-ae86eb8dcd46347a339a36a3753a9b28492431009c820d8624ddaf4080c17c15L663-R663) [[2]](diffhunk://#diff-ae86eb8dcd46347a339a36a3753a9b28492431009c820d8624ddaf4080c17c15R695-R702)

* [`src/shr/aqm_state_mod.F90`](diffhunk://#diff-c60983b3e7fd0a04be06b9f454c006b1f62b37deb2ffe39fd69a700d0cd9ac2fL9-R54): Added the `vtype` field to the `aqm_state_type` structure, ensuring it is included among the 2D variables.

## PR Checklist

  - [ x] RDHPCS.


- [ ] This PR has been tested with the ufs-srweather-app workflow online-cmaq branch.

- [ ] New or updated input data is required by this PR. <!-- If checked, please work with the code managers to update input data sets on all platforms.-->

- [x] Baselines are expected to change.

## Description
<!--Provide a detailed description of what this PR does.-->

## Issue(s) addressed
<!--Please link the issues to be closed with this PR.
(Remember, issues must always be created before starting work on a PR branch!)
EX: - fixes #<issue_number>-->

## Dependencies
<!--If testing this branch requires non-default branches in other repositories, list them. Those branches should have matching names (ideally).
Do PRs in upstream/other repositories need to be merged along with this one?
EX: - waiting on noaa-emc/fv3atm/pull/<pr_number>-->
