### PR TITLE
A temporary solution to fix erroneous values of LAI from noah-mp

### DIFF
--- a/src/shr/aqm_methods.F90
+++ b/src/shr/aqm_methods.F90
@@ -1221,7 +1221,20 @@ LOGICAL FUNCTION  XTRACT3 ( FNAME, VNAME,                           &
       case ("HFX")
         p2d => stateIn % hfx
       case ("LAI")
-        p2d => stateIn % xlai
+!        p2d => stateIn % xlai
+!     a temporary solution provided by Patrick Campbell from ARL for GFSv17 CCPP and
+!     AQMv8 coupling
+        k = 0
+        do r = row0, row1
+          do c = col0, col1  
+            k = k + 1
+               if ( stateIn % xlai(c,r) > 10.0 ) then  !zero out erroneously high values
+                 buffer(k) = 0.0 * stateIn % xlai(c,r) !from Noah-MP option, which should
+               else                                    !max out at ~ 4.5 from tables and
+                 buffer(k) = stateIn % xlai(c,r)       !~ 10 from satellite input data
+               end if
+          end do 
+        end do   
       case ("LH")
         p2d => stateIn % lh
       case ("PRSFC")


### PR DESCRIPTION


<!--Instructions: All subsequent sections of text should be filled in as appropriate.-->
## PR Checklist
- [ ] This PR has been tested on an RDHPCS machine and/or WCOSS2. Please select below:
  - [ ] RDHPCS.
  - [x] WCOSS2.

- [ ] This PR has been tested with the ufs-srweather-app workflow online-cmaq branch.

- [ ] New or updated input data is required by this PR. <!-- If checked, please work with the code managers to update input data sets on all platforms.-->

- [ ] Baselines are expected to change.

## Description
<!--Provide a detailed description of what this PR does.-->
This PR is intended to fix erroneous values of LAI coming from Noah-MP LSM (over snow/ice land use types) that breaks the AQM for some grid cells in the NA domain when testing the GFSv17 CCPP package with Noah-MP LSM for AQM

## Issue(s) addressed
<!--Please link the issues to be closed with this PR.
(Remember, issues must always be created before starting work on a PR branch!)
EX: - fixes #<115>-->https://github.com/NOAA-EMC/AQM/issues/115

## Dependencies
<!--If testing this branch requires non-default branches in other repositories, list them. Those branches should have matching names (ideally).
Do PRs in upstream/other repositories need to be merged along with this one?
EX: - waiting on noaa-emc/fv3atm/pull/<pr_number>-->
