### PR TITLE
Revert "Fix inconsistencies in canopy arrays to allow build in DEBUG mode."

### DIFF
--- a/src/model/src/can_levs_defn.F90
+++ b/src/model/src/can_levs_defn.F90
@@ -144,7 +144,7 @@
              CONC_2M  (NCOLS, NROWS,        NSPCSD), &
     KHETERO_CAN(NHETERO,NCOLS, NROWS, NLAYT), &
                                   zmid     (NLAYS)  , &
-                                  zmom     (NLAYS+1)  , & ! Same as zfull !
+                                  zmom     (NLAYS)  , & ! Same as zfull !
                                   sigmom   (NLAYS)  , &
                                   z2       (NLAYS+1), &
                                   sigmid2  (NLAYS+1), &

--- a/src/model/src/can_trans_mod.F90
+++ b/src/model/src/can_trans_mod.F90
@@ -590,8 +590,8 @@ module can_trans_mod
             kk = NLAYT
             do k = NLAYT, NLAYT-8, -1
                ! Paul's zt (MV3D_ZPLUS) is our zmid
-               if (diag_hgt <= zmid_can(COL,ROW,k-1) .and. &
-                  diag_hgt > zmid_can(COL,ROW,k)) then
+               if (diag_hgt <= zmid(k-1) .and. &
+                  diag_hgt > zmid(k)) then
                   kk = k - 1
                end if
             end do
@@ -605,8 +605,8 @@ module can_trans_mod
                mmr_diag =  &
                         mmr_canopy(kk) +                    &
                        (mmr_canopy(kk) - mmr_canopy(kk + 1)) / &
-                          (zmid_can(COL,ROW,kk) -    zmid_can(COL,ROW,kk + 1)) * &
-                          (diag_hgt -    zmid_can(COL,ROW,kk + 1))        ! ug kg-1
+                          (zmid(kk) -    zmid(kk + 1)) * &
+                          (diag_hgt -    zmid(kk + 1))        ! ug kg-1
                vmr_resolved      (NLAYS + 1)      = FOR_CONV(isp) * mmr_diag
             end if
 

--- a/src/model/src/phot.F
+++ b/src/model/src/phot.F
@@ -474,7 +474,7 @@ C...modules
          END IF
 
          ALLOCATE( ZFT       (NLAYT),
-     &             rj_corrf  (NLAYT+1),
+     &             rj_corrf  (NLAYT),
      &             rj_corrmid(NLAYT), STAT = ALLOCSTAT)
          IF ( ALLOCSTAT .NE. 0 ) THEN
               XMSG = 'Failure allocating canopy RJ correction arrays'
@@ -2273,7 +2273,7 @@ C...modules
 ! canopy_transfer:
 !    &      CONC_MOD  (:,:, 1  , LGC_NO2)  ) ) THEN
 !    &      CONC_CAN  (:,:, 3  , LGC_O3 )  ) ) THEN
-!    &      CONC_2M   (:,:     , LGC_NO2)  ) ) THEN
+!    &      CONC_2M   (:,:,    , LGC_NO2)  ) ) THEN
 !    & float(ifrct (NLAYS    ,1,:,:))    ) ) THEN
 !    & float(ifrct (NLAYT    ,1,:,:))    ) ) THEN   ! 1st (bot) canopy layer
 !


### PR DESCRIPTION
Reverts NOAA-EMC/AQM#124. Need to remerged after passing the RT tests